### PR TITLE
Making line number anchors clickable for HTML rendering

### DIFF
--- a/Text/Highlighting/Kate/Format/HTML.hs
+++ b/Text/Highlighting/Kate/Format/HTML.hs
@@ -89,10 +89,10 @@ formatHtmlBlock opts ls = container ! A.class_ (toValue $ unwords classes)
                      $ H.pre
                      $ mapM_ lineNum [startNum..(startNum + length ls - 1)]
          lineNum n = if lineAnchors opts
-                        then (H.a ! A.id (toValue $ show n) $ toHtml $ show n)
+                        then (H.a ! A.id (toValue nStr) ! A.href (toValue $ "#" ++ nStr) $ toHtml $ show n)
                               >> toHtml "\n"
                         else toHtml $ show n ++ "\n"
-
+           where nStr = show n
 -- | Returns CSS for styling highlighted code according to the given style.
 styleToCss :: Style -> String
 styleToCss f = unlines $ tablespec ++ colorspec ++ map toCss (tokenStyles f)


### PR DESCRIPTION
This simple change just adds a link on line numbers so that they become clickable and we thus then just have to copy/paste the URL when willing to show a particular line to someone.
