### PR TITLE
Update Curry highlighting to version 0.2

### DIFF
--- a/xml/curry.xml
+++ b/xml/curry.xml
@@ -8,11 +8,29 @@
   <!-- Type -->
   <!ENTITY type        "[A-Z][a-zA-Z0-9_']*">
   <!-- infix operator characters -->
-  <!ENTITY infixchar   "~!@#\$&#37;\^&amp;\*\+\-=&lt;&gt;\?\./\|\\:">
+  <!ENTITY infixchar   "~!@#\$&#37;\^&amp;\*\+\-=&lt;&gt;\?\./\|&backslash;:">
   <!-- identifier in prefix notation, e.g.: id, ($) -->
   <!ENTITY prefixIdent "(&ident;|\([&infixchar;]+\))">
+
+  <!-- Characters allowed in character escape sequence, e.g., \n -->
+  <!ENTITY escSeqChar  "abfnrtv\&quot;'" >
+  <!-- Ascii escape sequence, e.g., \NUL -->
+  <!ENTITY escSeqAscii "NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL" >
+  <!-- Control escape sequence, e.g., \^X -->
+  <!ENTITY escSeqCntrl "\^[A-Z@\[&backslash;\]\^_]" >
+
+  <!-- octal number -->
+  <!ENTITY octal       "[0-7]+" >
+  <!-- decimal number -->
+  <!ENTITY decimal     "[0-9]+" >
+  <!-- hexadecimal number -->
+  <!ENTITY hexadecimal "[0-9a-fA-F]+" >
+  <!-- a backslash, escaped for use in regular expressions -->
+  <!ENTITY backslash   "\\" >
+  <!-- dashes introducing a currydoc comment -->
+  <!ENTITY currydoc    "---" >
 ]>
-<language name="Curry" version="0.1" kateversion="2.3"
+<language name="Curry" version="0.2" kateversion="2.3"
           section="Sources" extensions="*.curry" mimetype="text/x-curry"
           author="Björn Peemöller (bjp@informatik.uni-kiel.de)" license="LGPL"
           indenter="haskell">
@@ -42,7 +60,7 @@
     <item> type </item>
     <item> where </item>
   </list>
-  <list name="Prelude Fun">
+  <list name="Prelude Func">
     <item> and </item>
     <item> all </item>
     <item> any </item>
@@ -164,120 +182,176 @@
     <item> GT </item>
   </list>
   <contexts>
-    <context attribute="Normal" lineEndContext="#stay" name="Normal">
+    <context name="Normal" attribute="Normal" lineEndContext="#stay">
       <!-- pragmas, currydoc, comments -->
-      <StringDetect attribute="Pragma"      context="Pragma"            String="{-#"        beginRegion="Pragma"  />
-      <Detect2Chars attribute="Comment"     context="Multiline Comment" char="{" char1="-"  beginRegion="Comment" />
-      <StringDetect attribute="Currydoc"    context="Currydoc"          String="---"        />
-      <Detect2Chars attribute="Comment"     context="Comment"           char="-" char1="-"  />
+      <StringDetect attribute="Pragma"   context="Pragma"            String="{-#"        beginRegion="Pragma"  />
+      <Detect2Chars attribute="Comment"  context="Multiline Comment" char="{" char1="-"  beginRegion="Multiline Comment" />
+      <StringDetect attribute="Currydoc" context="Currydoc"          String="&currydoc;" />
+      <Detect2Chars attribute="Comment"  context="Comment"           char="-" char1="-"  />
 
       <!-- keywords, Prelude entities -->
-      <keyword      attribute="Keyword"     context="#stay"   String="keywords" />
-      <keyword      attribute="Prelude"     context="#stay"   String="Prelude Fun" />
-      <keyword      attribute="Type"        context="#stay"   String="Prelude Type" />
-      <keyword      attribute="Constructor" context="#stay"   String="Prelude Cons" />
-      <RegExpr      attribute="Keyword"     context="Import"  String="import\s+(qualified)?" />
+      <keyword      attribute="Keyword"             context="#stay"   String="keywords" />
+      <keyword      attribute="Prelude Function"    context="#stay"   String="Prelude Func" />
+      <keyword      attribute="Prelude Type"        context="#stay"   String="Prelude Type" />
+      <keyword      attribute="Prelude Constructor" context="#stay"   String="Prelude Cons" />
+      <RegExpr      attribute="Keyword"             context="Import"  String="import\s+(qualified)?" />
 
       <!-- Literals -->
-      <Float        attribute="Float"       context="#stay"   />
-      <RegExpr      attribute="Octal"       context="#stay"   String="0(o|O)[0-7]+" />
-      <HlCHex       attribute="Hex"         context="#stay"   />
-      <Int          attribute="Decimal"     context="#stay"   />
-      <DetectChar   attribute="Char"        context="Char"    char="'" />
-      <DetectChar   attribute="String"      context="String"  char="&quot;" />
+      <Float        attribute="Float"   context="#stay"   />
+      <RegExpr      attribute="Octal"   context="#stay"   String="0(o|O)&octal;" />
+      <HlCHex       attribute="Hex"     context="#stay"   />
+      <Int          attribute="Decimal" context="#stay"   />
+      <DetectChar   attribute="Char"    context="Char"    char="'" />
+      <DetectChar   attribute="String"  context="String"  char="&quot;" />
 
       <!-- Others -->
-      <RegExpr      attribute="Special"     context="#stay"   String="(::|:=|:&gt;|\-&gt;|&lt;\-|\.\.)" />
-      <RegExpr      attribute="Signature"   context="#stay"   String="\s*&prefixIdent;\s*(,\s*&prefixIdent;)*\s*(?=::[^&infixchar;])" />
-      <RegExpr      attribute="Function"    context="#stay"   String="&qualify;&ident;" />
-      <RegExpr      attribute="Operator"    context="#stay"   String="&qualify;[&infixchar;]+" />
-      <RegExpr      attribute="Type"        context="#stay"   String="&qualify;&type;" />
-      <DetectChar   attribute="Infix"       context="Infix"   char="`" />
+      <RegExpr      attribute="Special Symbol"    context="#stay"   String="(::|:=|:&gt;|\-&gt;|&lt;\-|\.\.)" />
+      <RegExpr      attribute="Signature"         context="#stay"   String="\s*&prefixIdent;\s*(,\s*&prefixIdent;)*\s*(?=::[^&infixchar;])" />
+      <RegExpr      attribute="Function"          context="#stay"   String="&qualify;&ident;" />
+      <RegExpr      attribute="Operator"          context="#stay"   String="&qualify;[&infixchar;]+" />
+      <RegExpr      attribute="Type, Constructor" context="#stay"   String="&qualify;&type;" />
+      <DetectChar   attribute="Infix Application" context="Infix"   char="`" />
+
+      <!-- Folding of braces -->
+      <DetectChar char="(" context="#stay" beginRegion="nested" attribute="Braces" />
+      <DetectChar char=")" context="#stay" endRegion="nested"   attribute="Braces" />
+      <DetectChar char="[" context="#stay" beginRegion="list"   attribute="Braces" />
+      <DetectChar char="]" context="#stay" endRegion="list"     attribute="Braces" />
+      <DetectChar char="{" context="#stay" beginRegion="curly"  attribute="Braces" />
+      <DetectChar char="}" context="#stay" endRegion="curly"    attribute="Braces" />
     </context>
 
     <!-- Pragma -->
-    <context attribute="Pragma"  lineEndContext="#stay" name="Pragma">
+    <context name="Pragma" attribute="Pragma" lineEndContext="#stay" >
       <StringDetect attribute="Pragma" context="#pop" String="#-}" endRegion="Pragma" />
     </context>
 
     <!-- Multiline comment -->
-    <context attribute="Comment"  lineEndContext="#stay" name="Multiline Comment">
-      <Detect2Chars attribute="Comment" context="#pop" char="-" char1="}" endRegion="Comment" />
+    <context name="Multiline Comment" attribute="Comment" lineEndContext="#stay" >
+      <Detect2Chars attribute="Comment" context="#pop" char="-" char1="}" endRegion="Multiline Comment" />
     </context>
 
     <!-- Currydoc -->
-    <context attribute="Currydoc" lineEndContext="#pop"  name="Currydoc" />
+    <context name="Currydoc" attribute="Currydoc" lineEndContext="#pop" />
 
     <!-- Single line comment -->
-    <context attribute="Comment"  lineEndContext="#pop"  name="Comment"  />
+    <context name="Comment" attribute="Comment" lineEndContext="#pop" />
 
     <!-- Import section -->
-    <context attribute="Normal" lineEndContext="#pop" name="Import">
-      <RegExpr      attribute="Type"    context="#stay" String="&qualify;&type;" />
-      <Detect2Chars attribute="Keyword" context="#stay" char="a" char1="s" />
-      <StringDetect attribute="Keyword" context="#stay" String="hiding" />
+    <context name="Import" attribute="Normal" lineEndContext="#pop" >
+      <RegExpr      attribute="Type, Constructor" context="#stay" String="&qualify;&type;" />
+      <Detect2Chars attribute="Keyword"           context="#stay" char="a" char1="s" />
+      <StringDetect attribute="Keyword"           context="#stay" String="hiding" />
       <!-- Pop context at open paren to highlight imported entities -->
-      <DetectChar   attribute="Normal" context="#pop"   char="(" />
-      <RegExpr      attribute="Error"  context="#stay"  String="\S+" />
+      <DetectChar   attribute="Braces"            context="#pop"   char="(" beginRegion="nested" />
+      <RegExpr      attribute="Syntax Error"      context="#stay"  String="\S+" />
     </context>
 
-    <!-- This could be more elaborate w.r.t escape sequences and restricting
-         to one character, but we keep it simple for the moment -->
-    <context attribute="Char" lineEndContext="#pop" name="Char">
-      <RegExpr    attribute="Char" context="#stay" String="\\." />
-      <DetectChar attribute="Char" context="#pop"  char="'" />
+    <!-- A single characters, with escape sequences -->
+    <context name="Char" attribute="Char" lineEndContext="CharSyntaxError" >
+      <DetectChar attribute="Syntax Error" context="#pop"       char="'" />
+      <DetectChar attribute="Char"         context="CharEscape" char="\" />
+      <RegExpr    attribute="Char"         context="CharEnd"    String="[^'&backslash;]" />
     </context>
 
-    <!-- This could be more elaborate, w.r.t escape sequences,
-         but we keep it simple for the moment -->
-    <context attribute="String" lineEndContext="#stay" name="String">
-      <RegExpr    attribute="String" context="#stay" String="\\." />
-      <DetectChar attribute="String" context="#pop"  char="&quot;" />
+    <!-- Character escape sequence -->
+    <context name="CharEscape" attribute="Char" lineEndContext="#popCharSyntaxError" >
+      <AnyChar attribute="Char"         context="#popCharEnd" String="&escSeqChar;"   />
+      <RegExpr attribute="Char"         context="#popCharEnd" String="o&octal;"       />
+      <RegExpr attribute="Char"         context="#popCharEnd" String="&decimal;"      />
+      <RegExpr attribute="Char"         context="#popCharEnd" String="x&hexadecimal;" />
+      <RegExpr attribute="Char"         context="#popCharEnd" String="&escSeqCntrl;"  />
+      <RegExpr attribute="Char"         context="#popCharEnd" String="&escSeqAscii;"  />
+      <RegExpr attribute="Syntax Error" context="#popCharEnd" String="."              />
+    </context>
+
+    <!-- Ending quote of character literal -->
+    <context name="CharEnd" attribute="Char" lineEndContext="#popCharSyntaxError" >
+      <DetectChar attribute="Char"         context="#pop#pop" char="'" />
+      <RegExpr    attribute="Syntax Error" context="#stay"    String="." />
+    </context>
+
+    <!-- Character syntax error: Newline inside literal -->
+    <context name="CharSyntaxError" attribute="Syntax Error" lineEndContext="#stay" >
+      <DetectChar attribute="Syntax Error" context="#pop#pop" char="'" />
+    </context>
+
+    <!-- A string, with escape sequences -->
+    <context name="String" attribute="String" lineEndContext="StringSyntaxError" >
+      <DetectChar   attribute="String"        context="#pop"         char="&quot;" />
+      <DetectChar   attribute="String Escape" context="StringEscape" char="\" />
+      <RegExpr      attribute="String"        context="#stay"        String="[^&quot;&backslash;]*" />
+    </context>
+
+    <!-- String escape sequence -->
+    <context name="StringEscape" attribute="String" lineEndContext="StringGap" >
+      <AnyChar      attribute="String Escape"  context="#pop"      String="&escSeqChar;&amp;" />
+      <RegExpr      attribute="String Escape"  context="#pop"      String="o&octal;"          />
+      <RegExpr      attribute="String Escape"  context="#pop"      String="&decimal;"         />
+      <RegExpr      attribute="String Escape"  context="#pop"      String="x&hexadecimal;"    />
+      <RegExpr      attribute="String Escape"  context="#pop"      String="&escSeqCntrl;"     />
+      <RegExpr      attribute="String Escape"  context="#pop"      String="&escSeqAscii;"     />
+      <DetectSpaces attribute="String Escape"  context="StringGap"                            />
+      <RegExpr      attribute="Syntax Error"   context="#pop"      String="."                 />
+    </context>
+
+    <context name="StringGap" attribute="String" lineEndContext="#stay" >
+      <DetectSpaces attribute="String Escape" context="#stay" />
+      <DetectChar   attribute="String Escape" context="#pop#pop#popString" char="\"      />
+      <DetectChar   attribute="Syntax Error"  context="#pop#pop#pop"       char="&quot;" />
+      <RegExpr      attribute="Syntax Error"  context="#stay"              String="."    />
+    </context>
+
+    <!-- String syntax error: Newline inside literal -->
+    <context name="StringSyntaxError" attribute="Syntax Error" lineEndContext="#stay" >
+      <DetectChar attribute="Syntax Error" context="#pop#pop" char="&quot;" />
     </context>
 
     <!-- Infix application -->
-    <context attribute="Infix" lineEndContext="#stay" name="Infix">
-      <DetectChar attribute="Infix" context="#pop" char="`"/>
+    <context name="Infix" attribute="Infix Application" lineEndContext="#stay" >
+      <DetectChar attribute="Infix Application" context="#pop" char="`"/>
     </context>
   </contexts>
 
   <itemDatas>
-    <itemData name="Normal"      defStyleNum="dsNormal"   spellChecking="false" />
+    <itemData name="Normal"              defStyleNum="dsNormal"   spellChecking="false" />
 
     <!-- Comments -->
-    <itemData name="Pragma"      defStyleNum="dsOthers"   spellChecking="false" />
-    <itemData name="Comment"     defStyleNum="dsComment"  />
-    <itemData name="Currydoc"    defStyleNum="dsComment"  color="#008000" selColor="#FFFFFF"/>
+    <itemData name="Pragma"              defStyleNum="dsOthers"   spellChecking="false" />
+    <itemData name="Comment"             defStyleNum="dsComment"  />
+    <itemData name="Currydoc"            defStyleNum="dsComment"  color="#008000" selColor="#FFFFFF"/>
 
     <!-- Keywords, predefined entities -->
-    <itemData name="Keyword"     defStyleNum="dsKeyword"  spellChecking="false" />
-    <itemData name="Type"        defStyleNum="dsDataType" spellChecking="false" />
-    <itemData name="Prelude"     defStyleNum="dsFunction" spellChecking="false" />
-    <itemData name="Constructor" defStyleNum="dsKeyword"  spellChecking="false" />
+    <itemData name="Keyword"             defStyleNum="dsKeyword"  spellChecking="false" />
+    <itemData name="Prelude Type"        defStyleNum="dsDataType" spellChecking="false" />
+    <itemData name="Prelude Function"    defStyleNum="dsFunction" spellChecking="false" />
+    <itemData name="Prelude Constructor" defStyleNum="dsKeyword"  spellChecking="false" />
 
     <!-- Literals -->
-    <itemData name="Float"       defStyleNum="dsFloat"    spellChecking="false" />
-    <itemData name="Octal"       defStyleNum="dsBaseN"    spellChecking="false" />
-    <itemData name="Hex"         defStyleNum="dsBaseN"    spellChecking="false" />
-    <itemData name="Decimal"     defStyleNum="dsDecVal"   spellChecking="false" />
-    <itemData name="Char"        defStyleNum="dsChar"     spellChecking="false" />
-    <itemData name="String"      defStyleNum="dsString"   />
+    <itemData name="Float"               defStyleNum="dsFloat"    spellChecking="false" />
+    <itemData name="Octal"               defStyleNum="dsBaseN"    spellChecking="false" />
+    <itemData name="Hex"                 defStyleNum="dsBaseN"    spellChecking="false" />
+    <itemData name="Decimal"             defStyleNum="dsDecVal"   spellChecking="false" />
+    <itemData name="Char"                defStyleNum="dsChar"     spellChecking="false" />
+    <itemData name="String Escape"       defStyleNum="dsChar"     spellChecking="false" />
+    <itemData name="String"              defStyleNum="dsString"   />
 
     <!-- Others -->
-    <itemData name="Signature"   defStyleNum="dsOthers"   spellChecking="false" />
-    <itemData name="Function"    defStyleNum="dsNormal"   spellChecking="false" />
-    <itemData name="Operator"    defStyleNum="dsFunction" spellChecking="false" />
-    <itemData name="Type"        defStyleNum="dsDataType" spellChecking="false" />
-    <itemData name="Special"     defStyleNum="dsOthers"   spellChecking="false" />
-    <itemData name="Infix"       defStyleNum="dsOthers"   spellChecking="false" />
-    <itemData name="Error"       defStyleNum="dsError"    spellChecking="false" />
+    <itemData name="Braces"              defStyleNum="dsNormal"   spellChecking="false" />
+    <itemData name="Signature"           defStyleNum="dsOthers"   spellChecking="false" />
+    <itemData name="Function"            defStyleNum="dsNormal"   spellChecking="false" />
+    <itemData name="Operator"            defStyleNum="dsFunction" spellChecking="false" />
+    <itemData name="Type, Constructor"   defStyleNum="dsDataType" spellChecking="false" />
+    <itemData name="Special Symbol"      defStyleNum="dsOthers"   spellChecking="false" />
+    <itemData name="Infix Application"   defStyleNum="dsOthers"   spellChecking="false" />
+    <itemData name="Syntax Error"        defStyleNum="dsError"    spellChecking="false" />
   </itemDatas>
   </highlighting>
   <general>
     <folding indentationsensitive="1"/>
     <comments>
       <comment name="singleLine" start="--" />
-      <comment name="multiLine" start="{-" end="-}" region="Comment" />
+      <comment name="multiLine" start="{-" end="-}" region="Multiline Comment" />
     </comments>
     <keywords casesensitive="1" />
   </general>

--- a/xml/literate-curry.xml
+++ b/xml/literate-curry.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE language SYSTEM "language.dtd">
-<language name="Literate Curry" version="0.1" kateversion="2.3"
+<language name="Literate Curry" version="0.2" kateversion="2.3"
           section="Sources" extensions="*.lcurry" mimetype="text/x-curry"
           author="Björn Peemöller (bjp@informatik.uni-kiel.de)" license="LGPL"
           indenter="haskell">


### PR DESCRIPTION
In response to the tips I got on the Kate developer mailing list,
I updated the highlighting to version 0.2. This version is now integrated
into the official kate repository, so that you can also download
the Curry highlighting via

  Configure Kate -> Open/Save -> Modes & Filetypes
  -> Down Highlighting Files ...

New features:
- Escape sequences in Char and String literals are recognized
- Char literals of illegal length (0, > 1) are marked as syntax errors
- Illegal escape sequences are marked as syntax errors
- String gaps are recognized and handled
- Parentheses, brackets and braces open/close a corresponding region
