### PR TITLE
allow blaze-html-0.7

### DIFF
--- a/highlighting-kate.cabal
+++ b/highlighting-kate.cabal
@@ -152,7 +152,7 @@ Library
     cpp-options:     -D_PCRE_LIGHT
   else
     Build-depends:   regex-pcre-builtin
-  Build-Depends:     parsec, mtl, blaze-html >= 0.4.2 && < 0.7
+  Build-Depends:     parsec, mtl, blaze-html >= 0.4.2 && < 0.8
   Exposed-Modules:   Text.Highlighting.Kate
                      Text.Highlighting.Kate.Syntax
                      Text.Highlighting.Kate.Types
@@ -271,7 +271,7 @@ Library
 
 Executable Highlight
   Main-Is:          Highlight.hs
-  Build-Depends:    base, containers, blaze-html >= 0.4.2 && < 0.7, filepath,
+  Build-Depends:    base, containers, blaze-html >= 0.4.2 && < 0.8, filepath,
                     highlighting-kate
   Hs-Source-Dirs:   extra
   Default-Language:    Haskell98


### PR DESCRIPTION
Builds fine with `blaze-html-0.7`.
