### PR TITLE
Fix typo in list append operator in pcre-light-using code.

### DIFF
--- a/Text/Highlighting/Kate/Common.hs
+++ b/Text/Highlighting/Kate/Common.hs
@@ -184,7 +184,7 @@ compileRegex :: String -> KateParser Regex
 #ifdef _PCRE_LIGHT
 compileRegex regexpStr = do
   st <- getState
-  let opts = [anchored] + [caseless | not (synStCaseSensitive st)]
+  let opts = [anchored] ++ [caseless | not (synStCaseSensitive st)]
   return $ compile ('.' : convertOctal regexpStr) opts
 #else
 compileRegex regexpStr = do


### PR DESCRIPTION
Text/Highlighting/Kate/Common.hs:187:25:
    No instance for (Num [PCREOption]) arising from a use of `+'
    Possible fix: add an instance declaration for (Num [PCREOption])
    In the expression:
      [anchored] + [caseless | not (synStCaseSensitive st)]
    In an equation for`opts':
        opts = [anchored] + [caseless | not (synStCaseSensitive st)]
    In the expression:
      do { st <- getState;
           let opts = ... + ...;
           return $ compile ('.' : convertOctal regexpStr) opts }
