### PR TITLE
Add unicode support.

### DIFF
--- a/highlighting-kate.cabal
+++ b/highlighting-kate.cabal
@@ -153,7 +153,7 @@ Library
     Build-depends:   pcre-light >= 0.4 && < 0.5
     cpp-options:     -D_PCRE_LIGHT
   else
-    Build-depends:   regex-pcre-builtin
+    Build-depends:   regex-pcre-builtin, utf8-string
   Build-Depends:     parsec, mtl, blaze-html >= 0.4.2 && < 0.8
   Exposed-Modules:   Text.Highlighting.Kate
                      Text.Highlighting.Kate.Syntax


### PR DESCRIPTION
The PCRE String backend does not properly support unicode, however the ByteString backend does, provided that PCRE is built with UTF8 support. UTF8 support is not yet released in regex-pcre-builtin but the support has been merged: see https://github.com/audreyt/regex-pcre-builtin/issues/3 and https://github.com/audreyt/regex-pcre-builtin/pull/4 for further background.

This patch enables the use of the ByteString backend and properly converts between UTF8 ByteStrings and Strings.

Proper unicode support is needed at least for Agda syntax highlighting (see https://git.reviewboard.kde.org/r/117167/), but there may be more syntax files that might rely on this (e.g. Haskell).
