### PR TITLE
doctype is case insensitive in html5

### DIFF
--- a/xml/html.xml
+++ b/xml/html.xml
@@ -17,7 +17,7 @@
     <DetectIdentifier/>
     <StringDetect attribute="Comment" context="Comment" String="&lt;!--" beginRegion="comment" />
     <StringDetect attribute="CDATA" context="CDATA" String="&lt;![CDATA[" beginRegion="cdata" />
-    <RegExpr attribute="Doctype" context="Doctype" String="&lt;!DOCTYPE\s+" insensitive="true" beginRegion="doctype"  />
+    <RegExpr attribute="Doctype" context="Doctype" String="&lt;!DOCTYPE\s+" insensitive="false" beginRegion="doctype"  />
     <RegExpr attribute="Processing Instruction" context="PI" String="&lt;\?[\w:-]*" beginRegion="pi" />
     <RegExpr attribute="Element" context="CSS" String="&lt;style\b" insensitive="true" beginRegion="style" />
     <RegExpr attribute="Element" context="JS" String="&lt;script\b" insensitive="true" beginRegion="script" />


### PR DESCRIPTION
Hi,

the declaration

``` html
<!doctype html>
```

is valid HTML5, but treated as an "er"(ror) token, because of the lowercase.
