### PR TITLE
Update makefile for use with sandboxes + ensure regex-posix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ ParseSyntaxFiles
 Text/Highlighting/Kate/Syntax.hs
 Text/Highlighting/Kate/Syntax/
 dist/
+.cabal-sandbox/
+cabal.sandbox.config

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ test:
 	cabal test
 
 ParseSyntaxFiles: ParseSyntaxFiles.hs
-	cabal install HXT
-	ghc --make -Wall ParseSyntaxFiles.hs  # requires HXT >= 9.0.0
+	cabal install HXT regex-posix
+	cabal exec ghc -- --make -Wall ParseSyntaxFiles.hs  # requires HXT >= 9.0.0
 
 clean:
 	rm -rf Text/Highlighting/Kate/Syntax/*


### PR DESCRIPTION
This patch also makes sure the regex-posix package is installed, in order to use `Text.Regex.Posix.(=~)`. 

I am not sure about the regex-posix part though.