### PR TITLE
Idris syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Currently, the following languages/formats are supported:
 - Haskell
 - Haxe
 - Html
+- Idris
 - Ini
 - Isocpp
 - Java

--- a/highlighting-kate.cabal
+++ b/highlighting-kate.cabal
@@ -159,6 +159,7 @@ Library
                      Text.Highlighting.Kate.Syntax.Haskell
                      Text.Highlighting.Kate.Syntax.Haxe
                      Text.Highlighting.Kate.Syntax.Html
+                     Text.Highlighting.Kate.Syntax.Idris
                      Text.Highlighting.Kate.Syntax.Ini
                      Text.Highlighting.Kate.Syntax.Isocpp
                      Text.Highlighting.Kate.Syntax.Java

--- a/tests/abc.idris
+++ b/tests/abc.idris
@@ -1,0 +1,61 @@
+||| Blatantly copied from abc.haskell with some extra constructs
+|||
+||| Main module
+module Main
+
+%default total
+%access private
+
+data Vect' : Nat -> a -> Type where
+  Nil : Vect' 0 a
+  (::) : (x : a) -> (xs : Vect' n a) -> Vect' (S n) a
+
+instance Foldable (Vect' n) where
+  foldr f e xs = go f e id xs
+   where
+    go : (t -> acc -> acc) -> acc -> (acc -> acc) -> Vect' n t -> acc
+    go f e g [] = g e
+    go f e g (x :: xs) = go f e (g . (f x)) xs
+
+infixr 7 ++
+
+(++) : (xs' : Vect' m a) -> Vect' n a -> Vect' (m + n) a
+[] ++ ys = ys
+(x :: xs') ++ ys = x :: (xs' ++ ys)
+
+lemma_plus_associativity : (m : Nat) -> (n : Nat) -> (k : Nat) -> m + (n + k) = (m + n) + k
+lemma_plus_associativity m n k = ?lemma_plus_associativity_rhs
+
+-- returns list of all solutions
+--
+-- each solution being a list of blocks
+abc : Vect' n String -> String -> List (List String)
+abc blocks = go (toList blocks) . unpack
+ where
+  go : List String -> List Char -> List (List String)
+  go _ [] = [[]]
+  go blocks (c :: cs) = [ b :: ans | b <- blocks, c `elem` (unpack b), ans <- go (delete b blocks) cs ]
+
+{-
+This is a test of nested {- multiline
+comment -}
+-}
+blocks : Vect' 20 String
+blocks = ["BO", "XK", "DQ", "CP", "NA", "GT", "RE", "TG", "QD", "FS",
+          "JW", "HU", "VI", "AN", "OB", "ER", "FS", "LY", "PC", "ZM"]
+
+public main : IO ()
+main = traverse_ (\w => print (w, not . (== 0) . length $ abc blocks $ toUpper w)) $
+  the (List String) [ "", "A", "BARK", "BoOK", "TrEAT", "COmMoN", "SQUAD", "conFUsE" ]
+
+---------- Proofs ----------
+
+Main.lemma_plus_associativity_rhs = proof
+  intros
+  induction m
+  compute
+  trivial
+  intros
+  compute
+  rewrite ihn__0 
+  trivial

--- a/tests/abc.idris.html
+++ b/tests/abc.idris.html
@@ -1,0 +1,78 @@
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><style type="text/css">table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
+  margin: 0; padding: 0; vertical-align: baseline; border: none; }
+table.sourceCode { width: 100%; line-height: 100%; }
+td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
+td.sourceCode { padding-left: 5px; }
+code > span.kw { color: #007020; font-weight: bold; }
+code > span.dt { color: #902000; }
+code > span.dv { color: #40a070; }
+code > span.bn { color: #40a070; }
+code > span.fl { color: #40a070; }
+code > span.ch { color: #4070a0; }
+code > span.st { color: #4070a0; }
+code > span.co { color: #60a0b0; font-style: italic; }
+code > span.ot { color: #007020; }
+code > span.al { color: #ff0000; font-weight: bold; }
+code > span.fu { color: #06287e; }
+code > span.er { color: #ff0000; font-weight: bold; }
+</style></head><body><pre class="sourceCode"><code class="sourceCode"><span class="co" title="CommentTok">||| Blatantly copied from abc.haskell with some extra constructs</span>
+<span class="co" title="CommentTok">|||</span>
+<span class="co" title="CommentTok">||| Main module</span>
+<span class="kw" title="KeywordTok">module</span> <span class="dt" title="DataTypeTok">Main</span>
+
+<span class="kw" title="KeywordTok">%default</span> <span class="kw" title="KeywordTok">total</span>
+<span class="kw" title="KeywordTok">%access</span> <span class="kw" title="KeywordTok">private</span>
+
+<span class="kw" title="KeywordTok">data</span> <span class="dt" title="DataTypeTok">Vect&#39;</span> <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">Nat</span> <span class="ot" title="OtherTok">-&gt;</span> a <span class="ot" title="OtherTok">-&gt;</span> <span class="dt" title="DataTypeTok">Type</span> <span class="kw" title="KeywordTok">where</span>
+  <span class="dt" title="DataTypeTok">Nil</span> <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">Vect&#39;</span> <span class="dv" title="DecValTok">0</span> a
+  <span class="fu" title="FunctionTok">(::)</span> <span class="ot" title="OtherTok">:</span> (x <span class="ot" title="OtherTok">:</span> a) <span class="ot" title="OtherTok">-&gt;</span> (xs <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">Vect&#39;</span> n a) <span class="ot" title="OtherTok">-&gt;</span> <span class="dt" title="DataTypeTok">Vect&#39;</span> (<span class="dt" title="DataTypeTok">S</span> n) a
+
+<span class="kw" title="KeywordTok">instance</span> <span class="dt" title="DataTypeTok">Foldable</span> (<span class="dt" title="DataTypeTok">Vect&#39;</span> n) <span class="kw" title="KeywordTok">where</span>
+  foldr f e xs <span class="fu" title="FunctionTok">=</span> go f e id xs
+   <span class="kw" title="KeywordTok">where</span>
+    <span class="fu" title="FunctionTok">go</span> <span class="ot" title="OtherTok">:</span> (t <span class="ot" title="OtherTok">-&gt;</span> acc <span class="ot" title="OtherTok">-&gt;</span> acc) <span class="ot" title="OtherTok">-&gt;</span> acc <span class="ot" title="OtherTok">-&gt;</span> (acc <span class="ot" title="OtherTok">-&gt;</span> acc) <span class="ot" title="OtherTok">-&gt;</span> <span class="dt" title="DataTypeTok">Vect&#39;</span> n t <span class="ot" title="OtherTok">-&gt;</span> acc
+    go f e g [] <span class="fu" title="FunctionTok">=</span> g e
+    go f e g (x <span class="ot" title="OtherTok">::</span> xs) <span class="fu" title="FunctionTok">=</span> go f e (g <span class="fu" title="FunctionTok">.</span> (f x)) xs
+
+<span class="kw" title="KeywordTok">infixr</span> <span class="dv" title="DecValTok">7</span> <span class="fu" title="FunctionTok">++</span>
+
+<span class="fu" title="FunctionTok">(++)</span> <span class="ot" title="OtherTok">:</span> (xs&#39; <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">Vect&#39;</span> m a) <span class="ot" title="OtherTok">-&gt;</span> <span class="dt" title="DataTypeTok">Vect&#39;</span> n a <span class="ot" title="OtherTok">-&gt;</span> <span class="dt" title="DataTypeTok">Vect&#39;</span> (m <span class="fu" title="FunctionTok">+</span> n) a
+[] <span class="fu" title="FunctionTok">++</span> ys <span class="fu" title="FunctionTok">=</span> ys
+(x <span class="ot" title="OtherTok">::</span> xs&#39;) <span class="fu" title="FunctionTok">++</span> ys <span class="fu" title="FunctionTok">=</span> x <span class="ot" title="OtherTok">::</span> (xs&#39; <span class="fu" title="FunctionTok">++</span> ys)
+
+<span class="fu" title="FunctionTok">lemma_plus_associativity</span> <span class="ot" title="OtherTok">:</span> (m <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">Nat</span>) <span class="ot" title="OtherTok">-&gt;</span> (n <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">Nat</span>) <span class="ot" title="OtherTok">-&gt;</span> (k <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">Nat</span>) <span class="ot" title="OtherTok">-&gt;</span> m <span class="fu" title="FunctionTok">+</span> (n <span class="fu" title="FunctionTok">+</span> k) <span class="fu" title="FunctionTok">=</span> (m <span class="fu" title="FunctionTok">+</span> n) <span class="fu" title="FunctionTok">+</span> k
+lemma_plus_associativity m n k <span class="fu" title="FunctionTok">=</span> <span class="ot" title="OtherTok">?lemma_plus_associativity_rhs</span>
+
+<span class="co" title="CommentTok">-- returns list of all solutions</span>
+<span class="co" title="CommentTok">--</span>
+<span class="co" title="CommentTok">-- each solution being a list of blocks</span>
+<span class="fu" title="FunctionTok">abc</span> <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">Vect&#39;</span> n <span class="dt" title="DataTypeTok">String</span> <span class="ot" title="OtherTok">-&gt;</span> <span class="dt" title="DataTypeTok">String</span> <span class="ot" title="OtherTok">-&gt;</span> <span class="dt" title="DataTypeTok">List</span> (<span class="dt" title="DataTypeTok">List</span> <span class="dt" title="DataTypeTok">String</span>)
+abc blocks <span class="fu" title="FunctionTok">=</span> go (toList blocks) <span class="fu" title="FunctionTok">.</span> unpack
+ <span class="kw" title="KeywordTok">where</span>
+  <span class="fu" title="FunctionTok">go</span> <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">List</span> <span class="dt" title="DataTypeTok">String</span> <span class="ot" title="OtherTok">-&gt;</span> <span class="dt" title="DataTypeTok">List</span> <span class="dt" title="DataTypeTok">Char</span> <span class="ot" title="OtherTok">-&gt;</span> <span class="dt" title="DataTypeTok">List</span> (<span class="dt" title="DataTypeTok">List</span> <span class="dt" title="DataTypeTok">String</span>)
+  go <span class="fu" title="FunctionTok">_</span> [] <span class="fu" title="FunctionTok">=</span> [[]]
+  go blocks (c <span class="ot" title="OtherTok">::</span> cs) <span class="fu" title="FunctionTok">=</span> [ b <span class="ot" title="OtherTok">::</span> ans <span class="fu" title="FunctionTok">|</span> b <span class="ot" title="OtherTok">&lt;-</span> blocks, c <span class="fu" title="FunctionTok">`elem`</span> (unpack b), ans <span class="ot" title="OtherTok">&lt;-</span> go (delete b blocks) cs ]
+
+<span class="co" title="CommentTok">{-</span>
+<span class="co" title="CommentTok">This is a test of nested {- multiline</span>
+<span class="co" title="CommentTok">comment -}</span>
+<span class="co" title="CommentTok">-}</span>
+<span class="fu" title="FunctionTok">blocks</span> <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">Vect&#39;</span> <span class="dv" title="DecValTok">20</span> <span class="dt" title="DataTypeTok">String</span>
+blocks <span class="fu" title="FunctionTok">=</span> [<span class="st" title="StringTok">&quot;BO&quot;</span>, <span class="st" title="StringTok">&quot;XK&quot;</span>, <span class="st" title="StringTok">&quot;DQ&quot;</span>, <span class="st" title="StringTok">&quot;CP&quot;</span>, <span class="st" title="StringTok">&quot;NA&quot;</span>, <span class="st" title="StringTok">&quot;GT&quot;</span>, <span class="st" title="StringTok">&quot;RE&quot;</span>, <span class="st" title="StringTok">&quot;TG&quot;</span>, <span class="st" title="StringTok">&quot;QD&quot;</span>, <span class="st" title="StringTok">&quot;FS&quot;</span>,
+          <span class="st" title="StringTok">&quot;JW&quot;</span>, <span class="st" title="StringTok">&quot;HU&quot;</span>, <span class="st" title="StringTok">&quot;VI&quot;</span>, <span class="st" title="StringTok">&quot;AN&quot;</span>, <span class="st" title="StringTok">&quot;OB&quot;</span>, <span class="st" title="StringTok">&quot;ER&quot;</span>, <span class="st" title="StringTok">&quot;FS&quot;</span>, <span class="st" title="StringTok">&quot;LY&quot;</span>, <span class="st" title="StringTok">&quot;PC&quot;</span>, <span class="st" title="StringTok">&quot;ZM&quot;</span>]
+
+<span class="kw" title="KeywordTok">public</span> <span class="fu" title="FunctionTok">main</span> <span class="ot" title="OtherTok">:</span> <span class="dt" title="DataTypeTok">IO</span> ()
+main <span class="fu" title="FunctionTok">=</span> traverse_ (<span class="fu" title="FunctionTok">\</span>w <span class="ot" title="OtherTok">=&gt;</span> print (w, not <span class="fu" title="FunctionTok">.</span> (<span class="fu" title="FunctionTok">==</span> <span class="dv" title="DecValTok">0</span>) <span class="fu" title="FunctionTok">.</span> length <span class="fu" title="FunctionTok">$</span> abc blocks <span class="fu" title="FunctionTok">$</span> toUpper w)) <span class="fu" title="FunctionTok">$</span>
+  the (<span class="dt" title="DataTypeTok">List</span> <span class="dt" title="DataTypeTok">String</span>) [ <span class="st" title="StringTok">&quot;&quot;</span>, <span class="st" title="StringTok">&quot;A&quot;</span>, <span class="st" title="StringTok">&quot;BARK&quot;</span>, <span class="st" title="StringTok">&quot;BoOK&quot;</span>, <span class="st" title="StringTok">&quot;TrEAT&quot;</span>, <span class="st" title="StringTok">&quot;COmMoN&quot;</span>, <span class="st" title="StringTok">&quot;SQUAD&quot;</span>, <span class="st" title="StringTok">&quot;conFUsE&quot;</span> ]
+
+<span class="co" title="CommentTok">---------- Proofs ----------</span>
+
+<span class="dt" title="DataTypeTok">Main</span><span class="fu" title="FunctionTok">.</span>lemma_plus_associativity_rhs <span class="fu" title="FunctionTok">=</span> <span class="kw" title="KeywordTok">proof</span>
+  <span class="kw" title="KeywordTok">intros</span>
+  <span class="kw" title="KeywordTok">induction</span> m
+  <span class="kw" title="KeywordTok">compute</span>
+  <span class="kw" title="KeywordTok">trivial</span>
+  <span class="kw" title="KeywordTok">intros</span>
+  <span class="kw" title="KeywordTok">compute</span>
+  <span class="kw" title="KeywordTok">rewrite</span> ihn__0 
+  <span class="kw" title="KeywordTok">trivial</span></code></pre></body>

--- a/xml/idris.xml
+++ b/xml/idris.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language SYSTEM "language.dtd">
+<!-- Based on haskell.xml and idris.vim (https://github.com/idris-hackers/idris-vim/blob/6bdb44b85406b75e3b3a4fa265deab1dbe8c6ff1/syntax/idris.vim) -->
+<language name="Idris" version="1.0" kateversion="3.4" section="Sources" extensions="*.idr" author="Alexander Shabalin" license="LGPL">
+  <highlighting>
+  <list name="keywords">
+    <item> abstract </item>
+    <item> auto </item>
+    <item> case </item>
+    <item> class </item>
+    <item> codata </item>
+    <item> covering </item>
+    <item> data </item>
+    <item> default </item>
+    <item> do </item>
+    <item> dsl </item>
+    <item> else </item>
+    <item> if </item>
+    <item> implicit </item>
+    <item> import </item>
+    <item> impossible </item>
+    <item> in </item>
+    <item> index_first </item>
+    <item> index_next </item>
+    <item> infix </item>
+    <item> infixl </item>
+    <item> infixr </item>
+    <item> instance </item>
+    <item> lambda </item>
+    <item> let </item>
+    <item> module </item>
+    <item> mututal </item>
+    <item> namespace </item>
+    <item> of </item>
+    <item> parameters </item>
+    <item> partial </item>
+    <item> pattern </item>
+    <item> postulate </item>
+    <item> prefix </item>
+    <item> private </item>
+    <item> proof </item>
+    <item> public </item>
+    <item> record </item>
+    <item> rewrite </item>
+    <item> static </item>
+    <item> syntax </item>
+    <item> tactics </item>
+    <item> term </item>
+    <item> then </item>
+    <item> total </item>
+    <item> using </item>
+    <item> variable </item>
+    <item> where </item>
+    <item> with </item>
+  </list>
+  <list name="directives">
+     <item> access </item>
+     <item> assert_total </item>
+     <item> default </item>
+     <item> dynamic </item>
+     <item> elim </item>
+     <item> error_handlers </item>
+     <item> error_reverse </item>
+     <item> flag </item>
+     <item> hide </item>
+     <item> include </item>
+     <item> language </item>
+     <item> lib </item>
+     <item> link </item>
+     <item> name </item>
+     <item> provide </item>
+     <item> reflection </item>
+  </list>
+  <list name="tactics">
+    <item> applyTactic </item>
+    <item> attack </item>
+    <item> compute </item>
+    <item> exact </item>
+    <item> fill </item>
+    <item> focus </item>
+    <item> induction </item>
+    <item> intro </item>
+    <item> intros </item>
+    <item> let </item>
+    <item> refine </item>
+    <item> reflect </item>
+    <item> rewrite </item>
+    <item> solve </item>
+    <item> trivial </item>
+    <item> try </item>
+  </list>
+  <contexts>
+     <context attribute="Normal" lineEndContext="#stay" name="code">
+        <RegExpr attribute="Comment" context="line comment"
+           String="---*[^!#\$%&amp;\*\+/&lt;=&gt;\?&#92;@\^\|~\.:]?" />
+        <RegExpr attribute="Comment" context="line comment"
+           String="\|\|\|[^\-!#\$%&amp;\*\+/&lt;=&gt;\?&#92;@\^\|~\.:]?" />
+        <Detect2Chars attribute="Comment" context="block comment" char="{" char1="-" />
+        <RegExpr attribute="Normal" context="declaration" lookAhead="true"
+           String="^\s*([a-z]+\s+)*([A-Za-z][A-Za-z0-9_]*'*|\([\-!#\$%&amp;\*\+\./&lt;=&gt;\?@&#92;\^\|~:]+\))\s*:" />
+        <keyword attribute="Keyword" context="#stay" String="keywords" />
+        <DetectChar attribute="Keyword" context="directive" char="%" />
+        <keyword attribute="Tactic" context="#stay" String="tactics" />
+        <DetectChar attribute="Char" context="char" char="'" />
+        <DetectChar attribute="String" context="string" char="&quot;" />
+        <Int attribute="Decimal" context="#stay" />
+        <RegExpr attribute="Hex" context="#stay" String="0[Xx][0-9A-Fa-f]+"/>
+        <RegExpr attribute="Octal" context="#stay" String="0[Xx][0-9A-Fa-f]+"/>
+        <RegExpr attribute="Float" context="#stay" String="\d+\.\d+([eE][-+]?\d+)?" />
+        <RegExpr attribute="Type" context="#stay" String="([A-Z][a-zA-Z0-9_]*'*|_\|_)" />
+        <RegExpr attribute="Normal" context="#stay" String="[a-z][a-zA-Z0-9_]*'*" />
+        <RegExpr attribute="MetaVar" context="#stay" String="\?[a-z][A-Za-z0-9_]+'*" />
+        <RegExpr attribute="Special" context="#stay" String="(:|=&gt;|\-&gt;|&lt;\-)" />
+        <RegExpr attribute="Operator" context="#stay"
+           String="([\-!#\$%&amp;\*\+\./&lt;=&gt;\?@&#92;\^\|~:]+|\b_\b)" />
+        <RegExpr attribute="Operator" context="#stay" String="`[A-Za-z][A-Za-z0-9_]*'*`" />
+     </context>
+     <context attribute="Normal" lineEndContext="#pop" name="declaration">
+        <keyword attribute="Keyword" context="#stay" String="keywords" />
+        <RegExpr attribute="Type" context="#stay" String="([A-Z][a-zA-Z0-9_]*'*|_\|_)" />
+        <RegExpr attribute="Declaration" context="#stay" String="[a-z][A-Za-z0-9_]*'*"/>
+        <RegExpr attribute="Operator" context="#stay"
+           String="\([\-!#\$%&amp;\*\+\./&lt;=&gt;\?@&#92;\^\|~:]+\)" />
+        <DetectChar attribute="Special" context="#pop" char=":" />
+     </context>
+     <context attribute="Normal" lineEndContext="#pop" name="directive">
+        <keyword attribute="Keyword" context="#stay" String="keywords" />
+        <keyword attribute="Keyword" context="#stay" String="directives" />
+     </context>
+     <context attribute="Char" lineEndContext="#pop" name="char">
+        <RegExpr attribute="Char" context="#stay" String="\\." />
+        <DetectChar attribute="Char" context="#pop" char="'" />
+     </context>
+     <context attribute="String" lineEndContext="#stay" name="string">
+        <RegExpr attribute="String" context="#stay" String="\\." />
+        <RegExpr attribute="String" context="#pop" String="&quot;" />
+     </context>
+     <context attribute="Comment" lineEndContext="#pop" name="line comment" />
+     <context attribute="Comment" lineEndContext="#stay" name="block comment">
+        <Detect2Chars attribute="Comment" context="#pop" char="-" char1="}" />
+        <Detect2Chars attribute="Comment" context="block comment" char="{" char1="-" />
+     </context>
+  </contexts>
+  <itemDatas>
+    <itemData name="Normal" defStyleNum="dsNormal" spellChecking="false" />
+    <itemData name="Comment" defStyleNum="dsComment" spellChecking="true" />
+    <itemData name="Keyword" defStyleNum="dsKeyword" spellChecking="false" />
+    <itemData name="Tactic" defStyleNum="dsKeyword" spellChecking="false" />
+    <itemData name="Char" defStyleNum="dsChar" spellChecking="false" />
+    <itemData name="String" defStyleNum="dsString" spellChecking="true" />
+    <itemData name="Decimal" defStyleNum="dsDecVal" spellChecking="false" />
+    <itemData name="Hex" defStyleNum="dsBaseN" spellChecking="false" />
+    <itemData name="Octal" defStyleNum="dsBaseN" spellChecking="false" />
+    <itemData name="Float" defStyleNum="dsFloat" spellChecking="false" />
+    <itemData name="Type" defStyleNum="dsDataType" spellChecking="false" />
+    <itemData name="MetaVar" defStyleNum="dsOthers" spellChecking="false" />
+    <itemData name="Operator" defStyleNum="dsFunction" spellChecking="false" />
+    <itemData name="Special" defStyleNum="dsOthers" spellChecking="false" />
+    <itemData name="Declaration" defStyleNum="dsFunction" spellChecking="false" />
+  </itemDatas>
+  </highlighting>
+  <general>
+    <folding indentationsensitive="1"/>
+    <comments>
+      <comment name="singleLine" start="--" />
+      <comment name="multiLine" start="{-" end="-}" />
+    </comments>
+    <keywords casesensitive="1" />
+</general>
+</language>


### PR DESCRIPTION
This adds syntax highlighting for [Idris](http://www.idris-lang.org).

It is based on highlighting rules for Haskell and on [idris-vim](https://github.com/idris-hackers/idris-vim/blob/6bdb44b85406b75e3b3a4fa265deab1dbe8c6ff1/syntax/idris.vim).

This patch is also up for submission [upstream](https://git.reviewboard.kde.org/r/122367/).