### PR TITLE
Bump blaze-html upper version bounds

### DIFF
--- a/highlighting-kate.cabal
+++ b/highlighting-kate.cabal
@@ -105,7 +105,7 @@ Library
     cpp-options:     -D_PCRE_LIGHT
   else
     Build-depends:   regex-pcre-builtin >= 0.94.4.8.8.35
-  Build-Depends:     parsec, mtl, blaze-html >= 0.4.2 && < 0.8, utf8-string
+  Build-Depends:     parsec, mtl, blaze-html >= 0.4.2 && < 0.9, utf8-string
   Exposed-Modules:   Text.Highlighting.Kate
                      Text.Highlighting.Kate.Syntax
                      Text.Highlighting.Kate.Types
@@ -242,7 +242,7 @@ Library
 
 Executable Highlight
   Main-Is:          Highlight.hs
-  Build-Depends:    base, containers, blaze-html >= 0.4.2 && < 0.8, filepath,
+  Build-Depends:    base, containers, blaze-html >= 0.4.2 && < 0.9, filepath,
                     highlighting-kate
   Hs-Source-Dirs:   extra
   Default-Language:    Haskell98
@@ -264,5 +264,5 @@ test-suite test-highlighting-kate
   Main-Is:        test-highlighting-kate.hs
   Hs-Source-Dirs: tests
   build-depends:  base >= 4, directory, highlighting-kate, filepath,
-                  process, Diff, containers, blaze-html >= 0.4.2 && < 0.8
+                  process, Diff, containers, blaze-html >= 0.4.2 && < 0.9
   default-language: Haskell98


### PR DESCRIPTION
Allow `highlighting-kate` to build with the latest version of `blaze-html` (0.8).