### PR TITLE
Wrap code block HTML table in a pre element

### DIFF
--- a/Text/Highlighting/Kate/Format/HTML.hs
+++ b/Text/Highlighting/Kate/Format/HTML.hs
@@ -72,12 +72,12 @@ formatHtmlBlockPre opts = H.pre . formatHtmlInline opts
 
 -- | Format tokens as an HTML @pre@ block. If line numbering is
 -- selected, this is put into a table row with line numbers in the
--- left cell.
+-- left cell and the table is wrapped in a @pre@ block.
 formatHtmlBlock :: FormatOptions -> [SourceLine] -> Html
 formatHtmlBlock opts ls = container ! A.class_ (toValue $ unwords classes)
   where  container = if numberLines opts
-                        then H.table $ H.tr ! A.class_ sourceCode
-                                     $ nums >> source
+                        then H.pre $ H.table $ H.tr ! A.class_ sourceCode
+                                             $ nums >> source
                         else pre
          sourceCode = toValue "sourceCode"
          classes = "sourceCode" :

--- a/highlighting-kate.cabal
+++ b/highlighting-kate.cabal
@@ -1,5 +1,5 @@
 Name:                highlighting-kate
-Version:             0.5.12
+Version:             0.5.13
 Cabal-Version:       >= 1.10
 Build-Type:          Simple
 Category:            Text


### PR DESCRIPTION
Syntax highlighted code blocks with line numbers are written out as HTML
tables which are impossible to format via styles for different screen
widths. This means that pandoc generated pages with code blocks must
have a fixed minimal width, making them hard to read on narrower
screens.

Wrapping the table in a pre block allows formating of code blocks to
have a horizontal scroll bar if the content doesn't fit the screen
width, by adding the following style:

    pre.sourceCode {
        overflow-x: auto;
    }

This enables pandoc to generate responsive HTML pages.

a Please enter the commit message for your changes. Lines starting