### PR TITLE
Allow '#' as an operator in Haskell.

### DIFF
--- a/xml/haskell.xml
+++ b/xml/haskell.xml
@@ -326,7 +326,7 @@
       <RegExpr attribute="Comment" context="comment"  String="--[^\-!#\$%&amp;\*\+/&lt;=&gt;\?&#92;@\^\|~\.:].*$" />
       <RegExpr attribute="Keyword" context="import"   String="import\s+" />
       <RegExpr attribute="C2HS Directive"  context="c2hs directive" String="\{#"/>
-      <RegExpr attribute="C2HS Directive"  context="c2hs include" String="#"/>
+      <RegExpr attribute="C2HS Directive"  context="c2hs include" String="#[a-zA-Z]"/>
 
       <keyword attribute="Keyword"          context="#stay" String="keywords" />
       <keyword attribute="Function Prelude" context="#stay" String="prelude function" />

--- a/xml/haskell.xml
+++ b/xml/haskell.xml
@@ -326,7 +326,7 @@
       <RegExpr attribute="Comment" context="comment"  String="--[^\-!#\$%&amp;\*\+/&lt;=&gt;\?&#92;@\^\|~\.:].*$" />
       <RegExpr attribute="Keyword" context="import"   String="import\s+" />
       <RegExpr attribute="C2HS Directive"  context="c2hs directive" String="\{#"/>
-      <RegExpr attribute="C2HS Directive"  context="c2hs include" String="#[a-zA-Z]"/>
+      <RegExpr attribute="C2HS Directive"  context="c2hs include" String="^((\s*#[a-zA-Z])|#)"/>
 
       <keyword attribute="Keyword"          context="#stay" String="keywords" />
       <keyword attribute="Function Prelude" context="#stay" String="prelude function" />


### PR DESCRIPTION
We use highlighting-kate for the Diagrams website [1] and we recently noticed that using `#` as an operator leads to poor highlighting.  Before applying this change we see this:

````
ghci> highlightAs "Haskell" "blah # ha"
[[(NormalTok,"blah "),(StringTok,"# ha")]]
````

And after we have this:

````
ghci> highlightAs "Haskell" "blah # ha"
[[(NormalTok,"blah "),(FunctionTok,"#"),(NormalTok," "),(NormalTok,"ha")]]
````

In both cases CPP or C2HS looks as expected:

````
> highlightAs "Haskell" "#ifdef ha"
[[(StringTok,"#ifdef ha")]]
````

I don't know if this is the right fix or not, but hopefully it is helpful.

[1]: http://projects.haskell.org/diagrams/