### PR TITLE
Doesn't build on GHC 7.0

### DIFF
--- a/highlighting-kate.cabal
+++ b/highlighting-kate.cabal
@@ -99,7 +99,7 @@ Source-repository head
 
 Library
   if flag(splitBase)
-    Build-Depends:   base >= 3 && < 5, containers
+    Build-Depends:   base >= 4.4 && < 5, containers
   else
     Build-Depends:   base < 3
   if flag(pcre-light)


### PR DESCRIPTION
```
Text/Highlighting/Kate/Syntax/Agda.hs:66:23:
    lexical error at character '\8320'
```

Error was introduced in highlighting-kate-0.5.10, I've revised the offending versions e.g. http://hackage.haskell.org/package/highlighting-kate-0.6/revisions/

Older GHC's - e.g. the `base < 3` flag - probably don't build either but I'm not able to test that.
