### PR TITLE
Add elixir syntax

### DIFF
--- a/highlighting-kate.cabal
+++ b/highlighting-kate.cabal
@@ -146,6 +146,7 @@ Library
                      Text.Highlighting.Kate.Syntax.Doxygenlua
                      Text.Highlighting.Kate.Syntax.Dtd
                      Text.Highlighting.Kate.Syntax.Eiffel
+                     Text.Highlighting.Kate.Syntax.Elixir
                      Text.Highlighting.Kate.Syntax.Email
                      Text.Highlighting.Kate.Syntax.Erlang
                      Text.Highlighting.Kate.Syntax.Fasm

--- a/tests/abc.elixir
+++ b/tests/abc.elixir
@@ -1,0 +1,12 @@
+defmodule Geometry do
+  def area_loop do
+    receive do
+      {:rectangle, w, h} ->
+        IO.puts("Area = #{w * h}")
+        area_loop()
+      {:circle, r} ->
+        IO.puts("Area = #{3.14 * r * r}")
+        area_loop()
+    end
+  end
+end

--- a/tests/abc.elixir.html
+++ b/tests/abc.elixir.html
@@ -1,0 +1,47 @@
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><style type="text/css">div.sourceCode { overflow-x: auto; }
+table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
+  margin: 0; padding: 0; vertical-align: baseline; border: none; }
+table.sourceCode { width: 100%; line-height: 100%; }
+td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
+td.sourceCode { padding-left: 5px; }
+code > span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code > span.dt { color: #902000; } /* DataType */
+code > span.dv { color: #40a070; } /* DecVal */
+code > span.bn { color: #40a070; } /* BaseN */
+code > span.fl { color: #40a070; } /* Float */
+code > span.ch { color: #4070a0; } /* Char */
+code > span.st { color: #4070a0; } /* String */
+code > span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code > span.ot { color: #007020; } /* Other */
+code > span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code > span.fu { color: #06287e; } /* Function */
+code > span.er { color: #ff0000; font-weight: bold; } /* Error */
+code > span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+code > span.cn { color: #880000; } /* Constant */
+code > span.sc { color: #4070a0; } /* SpecialChar */
+code > span.vs { color: #4070a0; } /* VerbatimString */
+code > span.ss { color: #bb6688; } /* SpecialString */
+code > span.im { } /* Import */
+code > span.va { color: #19177c; } /* Variable */
+code > span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code > span.op { color: #666666; } /* Operator */
+code > span.bu { } /* BuiltIn */
+code > span.ex { } /* Extension */
+code > span.pp { color: #bc7a00; } /* Preprocessor */
+code > span.at { color: #7d9029; } /* Attribute */
+code > span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code > span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code > span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+</style></head><body><div class="sourceCode"><pre class="sourceCode"><code class="sourceCode"><span class="kw" title="KeywordTok">defmodule</span> <span class="dt" title="DataTypeTok">Geometry</span> <span class="kw" title="KeywordTok">do</span>
+  <span class="kw" title="KeywordTok">def</span> area_loop <span class="kw" title="KeywordTok">do</span>
+    <span class="kw" title="KeywordTok">receive</span> <span class="kw" title="KeywordTok">do</span>
+      {<span class="st" title="StringTok">:rectangle</span>, w, h} -&gt;
+        <span class="dt" title="DataTypeTok">IO</span>.puts(<span class="st" title="StringTok">&quot;Area = </span><span class="ot" title="OtherTok">#{</span>w * h<span class="ot" title="OtherTok">}</span><span class="st" title="StringTok">&quot;</span>)
+        area_loop()
+      {<span class="st" title="StringTok">:circle</span>, r} -&gt;
+        <span class="dt" title="DataTypeTok">IO</span>.puts(<span class="st" title="StringTok">&quot;Area = </span><span class="ot" title="OtherTok">#{</span><span class="fl" title="FloatTok">3.14</span> * r * r<span class="ot" title="OtherTok">}</span><span class="st" title="StringTok">&quot;</span>)
+        area_loop()
+    <span class="kw" title="KeywordTok">end</span>
+  <span class="kw" title="KeywordTok">end</span>
+<span class="kw" title="KeywordTok">end</span></code></pre></div></body>

--- a/xml/elixir.xml
+++ b/xml/elixir.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language
+  SYSTEM 'language.dtd'>
+<!--
+  Elixir syntax highlighting definition for Kate.
+  Copyright (C) 2014  by Rubén Caro (ruben.caro.estevez@gmail.com)
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Library General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Library General Public License for more details.
+  You should have received a copy of the GNU Library General Public
+  License along with this library; if not, write to the
+  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  Boston, MA  02110-1301, USA.
+-->
+<!-- Hold the "language" opening tag on a single line, as mentioned in "language.dtd". -->
+<language author="Rubén Caro (ruben.caro.estevez@gmail.com)"
+          extensions="*.ex;*.exs;*.eex;*.xml.eex;*.js.eex"
+          indenter="elixir"
+          kateversion="3.13"
+          license="GPL"
+          mimetype="text/x-elixir"
+          name="Elixir"
+          section="Sources"
+          style="elixir"
+          version="0.1">
+  <highlighting>
+    <list name="keywords">
+      <item>do</item>
+      <item>end</item>
+      <item>case</item>
+      <item>bc</item>
+      <item>lc</item>
+      <item>for</item>
+      <item>if</item>
+      <item>cond</item>
+      <item>unless</item>
+      <item>try</item>
+      <item>receive</item>
+      <item>exit</item>
+      <item>after</item>
+      <item>rescue</item>
+      <item>catch</item>
+      <item>else</item>
+      <item>raise</item>
+      <item>throw</item>
+      <item>quote</item>
+      <item>unquote</item>
+      <item>super</item>
+      <item>and</item>
+      <item>not</item>
+      <item>or</item>
+      <item>when</item>
+      <item>xor</item>
+      <item>in</item>
+      <item>inlist</item>
+      <item>inbits</item>
+    </list>
+    <list name="pseudo-variables">
+      <item>nil</item>
+      <item>true</item>
+      <item>false</item>
+    </list>
+    <list name="definitions">
+      <item>fn</item>
+      <item>defmodule</item>
+      <item>def</item>
+      <item>defp</item>
+      <item>defprotocol</item>
+      <item>defimpl</item>
+      <item>defrecord</item>
+      <item>defstruct</item>
+      <item>defmacro</item>
+      <item>defmacrop</item>
+      <item>defdelegate</item>
+      <item>defcallback</item>
+      <item>defmacrocallback</item>
+      <item>defexception</item>
+      <item>defoverridable</item>
+    </list>
+    <list name="mixin-macros">
+      <item>import</item>
+      <item>require</item>
+      <item>alias</item>
+      <item>use</item>
+    </list>
+    <contexts>
+      <context attribute="Normal Text" lineEndContext="#stay" name="Normal">
+        <!-- "shebang" line -->
+        <RegExpr String="#!\/.*" attribute="Keyword" column="0" context="#stay"/>
+
+        <!-- Defined words -->
+        <keyword String="keywords" attribute="Keyword" context="#stay"/>
+        <keyword String="definitions" attribute="Definition" context="#stay"/>
+        <keyword String="pseudo-variables" attribute="Pseudo variable" context="#stay"/>
+        <keyword String="mixin-macros" attribute="Mixin macros" context="#stay"/>
+
+        <!-- special-character globals -->
+        <RegExpr String="\b[_A-Z]+[A-Z_0-9]+\b" attribute="Global Constant" context="#stay"/>
+
+        <!-- Generally a module or class name like "File", "MyModule_1", .. -->
+        <RegExpr String="\b[A-Z]+_*([0-9]|[a-z])[_a-zA-Z0-9]*\b" attribute="Constant" context="#stay"/>
+
+        <!-- Numeric values. Note that we have to allow underscores between two digits (thus the creepy regular expressions). -->
+        <RegExpr String="\b\-?0[xX]([0-9a-fA-F]|_[0-9a-fA-F])+" attribute="Hex" context="#stay"/>
+        <RegExpr String="\b\-?0[bB]([01]|_[01])+" attribute="Bin" context="#stay"/>
+        <RegExpr String="\b\-?0[1-7]([0-7]|_[0-7])*" attribute="Octal" context="#stay"/>
+        <RegExpr String="\b\-?[0-9]([0-9]|_[0-9])*\.[0-9]([0-9]|_[0-9])*([eE]\-?[1-9]([0-9]|_[0-9])*(\.[0-9]*)?)?" attribute="Float" context="#stay"/>
+        <RegExpr String="\b\-?[1-9]([0-9]|_[0-9])*\b" attribute="Dec" context="#stay"/>
+        <Int attribute="Dec" context="#stay"/>
+        <HlCChar attribute="Char" context="#stay"/>
+        <DetectChar attribute="Operator" char="." context="#stay"/>
+        <Detect2Chars attribute="Operator" char="&amp;" char1="&amp;" context="#stay"/>
+        <Detect2Chars attribute="Operator" char="|" char1="|" context="#stay"/>
+        <RegExpr String="\s[\?\:\%]\s" attribute="Operator" context="#stay"/>
+        <RegExpr String="[|&amp;&lt;&gt;\^\+*~\-=]+" attribute="Operator" context="#stay"/>
+        <!-- regexp hack -->
+        <RegExpr String="\s!" attribute="Operator" context="#stay"/>
+        <RegExpr String="/=\s" attribute="Operator" context="#stay" insensitive="0"/>
+        <StringDetect String="%=" attribute="Operator" context="#stay" insensitive="0"/>
+        <RegExpr String=":(@{1,2}|\$)?[a-zA-Z_][a-zA-Z0-9_]*[=?!]?" attribute="Symbol" context="#stay"/>
+        <RegExpr String="\b(@{1,2}|\$)?[a-zA-Z_][a-zA-Z0-9_]*[=?!]?:" attribute="Symbol" context="#stay"/>
+        <RegExpr String=":\[\]=?" attribute="Symbol" context="#stay"/>
+        <RegExpr String="@(module)?doc\s+&quot;&quot;&quot;" attribute="Attribute" context="Documentation"/>
+        <StringDetect String="&quot;&quot;&quot;" attribute="String" context="Triple Quoted String"/>
+        <DetectChar attribute="String" char="&quot;" context="Quoted String"/>
+        <DetectChar attribute="Raw String" char="'" context="Apostrophed String"/>
+        <DetectChar attribute="Command" char="`" context="Command String"/>
+        <StringDetect String="?#" attribute="Normal Text" context="#stay"/>
+        <DetectChar attribute="Comment" char="#" context="General Comment"/>
+        <DetectChar attribute="Delimiter" char="[" context="#stay"/>
+        <DetectChar attribute="Delimiter" char="]" context="#stay"/>
+        <RegExpr String="@[a-zA-Z_0-9]+" attribute="Attribute" context="#stay"/>
+        <!-- handle the different regular expression formats -->
+        <DetectChar attribute="Regular Expression" char="/" context="RegEx 1"/>
+        <DetectChar attribute="Normal Text" char=")" context="#stay"/>
+        <DetectIdentifier attribute="Normal Text" context="#stay"/>
+      </context>
+      <context attribute="Normal Text" lineEndContext="#stay" name="Find closing block brace">
+        <DetectChar attribute="Operator" char="}" context="#pop" endRegion="def bracketed block"/>
+        <IncludeRules context="Normal"/>
+      </context>
+      <context attribute="DocComment" lineEndContext="#stay" name="Documentation">
+        <StringDetect String="&quot;&quot;&quot;" attribute="Attribute" context="#pop"/>
+        <RegExpr attribute="MarkdownHead" String="^\s*#+\s.*[#]?$"/>
+        <RegExpr attribute="MarkdownBullet" String="^\s*[\*\+\-]\s"/>
+        <RegExpr attribute="MarkdownNumlist" String="^\s*[\d]+\.\s"/>
+        <RegExpr attribute="MarkdownCode" context="Markdown Code" String="^\s*\`\`\`\s*$"/>
+        <DetectSpaces />
+        <IncludeRules context="Normal Text##Markdown"/>
+      </context>
+      <context attribute="String" lineEndContext="#stay" name="Triple Quoted String">
+        <StringDetect String="&quot;&quot;&quot;" attribute="String" context="#pop"/>
+      </context>
+      <context attribute="String" lineEndContext="#stay" name="Quoted String">
+        <StringDetect String="\\" attribute="String" context="#stay"/>
+        <RegExpr String="\\\&quot;" attribute="String" context="#stay"/>
+        <RegExpr String="#@{1,2}" attribute="Substitution" context="Short Subst"/>
+        <Detect2Chars attribute="Substitution" char="#" char1="{" context="Subst"/>
+        <DetectChar attribute="String" char="&quot;" context="#pop"/>
+      </context>
+      <context attribute="Raw String" lineEndContext="#stay" name="Apostrophed String">
+        <StringDetect String="\\" attribute="String" context="#stay"/>
+        <RegExpr String="\\\'" attribute="String" context="#stay"/>
+        <DetectChar attribute="Raw String" char="'" context="#pop"/>
+      </context>
+      <context attribute="Command" lineEndContext="#stay" name="Command String">
+        <StringDetect String="\\" attribute="String" context="#stay"/>
+        <RegExpr String="\\\`" attribute="String" context="#stay"/>
+        <RegExpr String="#@{1,2}" attribute="Substitution" context="Short Subst"/>
+        <Detect2Chars attribute="Substitution" char="#" char1="{" context="Subst"/>
+        <DetectChar attribute="Command" char="`" context="#pop"/>
+      </context>
+      <context attribute="Regular Expression" lineEndContext="#stay" name="RegEx 1">
+        <RegExpr String="\\\/" attribute="Regular Expression" context="#stay"/>
+        <RegExpr String="#@{1,2}" attribute="Substitution" context="Short Subst"/>
+        <Detect2Chars attribute="Substitution" char="#" char1="{" context="Subst"/>
+        <RegExpr String="/[uiomxn]*" attribute="Regular Expression" context="#pop"/>
+      </context>
+      <!-- Substitutions can be nested -->
+      <context attribute="Normal Text" lineEndContext="#stay" name="Subst">
+        <DetectChar attribute="Substitution" char="}" context="#pop"/>
+        <!-- Highlight substitution as code. -->
+        <IncludeRules context="Normal"/>
+      </context>
+      <context attribute="Substitution" lineEndContext="#pop" name="Short Subst">
+        <!-- Check for e.g.: "#@var#@@xy" -->
+        <RegExpr String="#@{1,2}" attribute="Substitution" context="#stay"/>
+        <RegExpr String="\w(?!\w)" attribute="Substitution" context="#pop"/>
+      </context>
+      <context attribute="Comment" lineEndContext="#pop" name="Comment Line">
+      </context>
+      <context attribute="Comment" lineEndContext="#pop" name="General Comment">
+      </context>
+      <!-- rules to be included in all regexpr contexts -->
+      <context attribute="Regular Expression" lineEndContext="#stay" name="regexpr_rules">
+        <Detect2Chars attribute="Regular Expression" char="\" char1="\" context="#stay"/>
+        <RegExpr String="#@{1,2}" attribute="Substitution" context="Short Subst"/>
+        <Detect2Chars attribute="Substitution" char="#" char1="{" context="Subst"/>
+      </context>
+      <context attribute="MarkdownCode" lineEndContext="#stay" name="Markdown Code">
+        <RegExpr String="^\s*\`\`\`\s*$" attribute="MarkdownCode" context="#pop"/>
+      </context>
+    </contexts>
+    <itemDatas>
+      <itemData name="Global Constant" defStyleNum="dsDataType" color="#bb1188" bold="1"/>
+      <itemData name="Constant" defStyleNum="dsDataType" color="#bb1188" bold="1"/>
+      <itemData defStyleNum="dsNormal" name="Normal Text"/>
+      <itemData defStyleNum="dsKeyword" name="Keyword"/>
+      <itemData defStyleNum="dsOthers" name="Attribute Definition"/>
+      <itemData color="#0000FF" defStyleNum="dsKeyword" name="Access Control"/>
+      <itemData defStyleNum="dsKeyword" name="Definition"/>
+      <itemData defStyleNum="dsKeyword" name="Mixin macros"/>
+      <itemData defStyleNum="dsDecVal" name="Pseudo variable"/>
+      <itemData defStyleNum="dsDecVal" name="Dec"/>
+      <itemData defStyleNum="dsFloat" name="Float"/>
+      <itemData defStyleNum="dsChar" name="Char"/>
+      <itemData defStyleNum="dsBaseN" name="Octal"/>
+      <itemData defStyleNum="dsBaseN" name="Hex"/>
+      <itemData defStyleNum="dsBaseN" name="Bin"/>
+      <itemData color="#D40000" defStyleNum="dsString" name="Symbol"/>
+      <itemData defStyleNum="dsString" name="String"/>
+      <itemData color="#DD4A4A" defStyleNum="dsString" name="Raw String" selColor="#DD4A4A"/>
+      <itemData color="#AA3000" defStyleNum="dsString" name="Command"/>
+      <itemData color="#4000A7" defStyleNum="dsNormal" name="Message"/>
+      <itemData color="#4A5704" defStyleNum="dsOthers" name="Regular Expression"/>
+      <itemData defStyleNum="dsOthers" name="Substitution"/>
+      <itemData defStyleNum="dsNormal" name="Data"/>
+      <itemData bold="1" defStyleNum="dsDataType" name="Default globals"/>
+      <itemData defStyleNum="dsDataType" name="Global Variable"/>
+      <itemData defStyleNum="dsDataType" name="Constant Value"/>
+      <itemData defStyleNum="dsNormal" name="Member"/>
+      <itemData defStyleNum="dsOthers" name="Attribute"/>
+      <itemData defStyleNum="dsOthers" name="Class Variable"/>
+      <itemData defStyleNum="dsComment" name="Comment"/>
+      <itemData defStyleNum="dsComment" name="Blockcomment"/>
+      <itemData defStyleNum="dsComment" name="DocComment"/>
+      <itemData color="#0000ff" defStyleNum="dsNormal" name="Region Marker"/>
+      <!-- use these to mark errors and alerts things -->
+      <itemData defStyleNum="dsError" name="Error"/>
+      <itemData color="#FF9FEC" defStyleNum="dsNormal" name="Delimiter"/>
+      <itemData defStyleNum="dsOthers" name="Expression"/>
+      <itemData color="#FF9FEC" defStyleNum="dsNormal" name="Operator"/>
+      <itemData name="MarkdownHead" defStyleNum="dsFunction" bold="true"/>
+      <itemData name="MarkdownBullet" defStyleNum="dsFunction"/>
+      <itemData name="MarkdownNumlist" defStyleNum="dsFunction"/>
+      <itemData name="MarkdownCode" defStyleNum="dsFunction"/>
+    </itemDatas>
+  </highlighting>
+  <general>
+    <comments>
+      <comment name="singleLine" start="#"/>
+    </comments>
+    <keywords casesensitive="1" weakDeliminator="!?"/>
+  </general>
+</language>


### PR DESCRIPTION
Adds [Elixir](http://elixir-lang.org/) to the list of supported languages.

[Syntax document](https://gist.githubusercontent.com/rubencaro/7158f8c2ccd33f568504/raw/2aa320e06b7feec5fee637c2e4984edd9d7f9ce2/elixir.xml) provided by @rubencaro

This PR adds the syntax document, updates the README, and adds test files for Elixir syntax.