### PR TITLE
Added missing utf8-string dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ prof:
 	stack build --library-profiling --executable-profiling --fast
 
 prep: clean $(XMLS)
-	stack install --install-ghc hxt regex-posix
+	stack install --install-ghc hxt regex-posix utf8-string
 	stack runghc ./ParseSyntaxFiles.hs xml
 	@echo "Syntax parsers have been generated."
 	@echo "You may now use cabal to build the package."


### PR DESCRIPTION
The utf8-string package is required for Data.ByteString.UTF8 in ParseSyntaxFiles.hs:35. Without it the compilation fails on fresh installs.